### PR TITLE
Ignore binaryfileresponses

### DIFF
--- a/src/Listener/MonitoringTokenListener.php
+++ b/src/Listener/MonitoringTokenListener.php
@@ -4,6 +4,7 @@ namespace Becklyn\Hosting\Listener;
 
 use Becklyn\Hosting\Config\HostingConfig;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
@@ -31,7 +32,7 @@ class MonitoringTokenListener implements EventSubscriberInterface
     public function onResponse (FilterResponseEvent $event) : void
     {
         // skip if not master request
-        if (!$event->isMasterRequest() || null === $this->uptimeHtmlEmbed)
+        if (null === $this->uptimeHtmlEmbed || !$event->isMasterRequest())
         {
             return;
         }
@@ -60,7 +61,7 @@ class MonitoringTokenListener implements EventSubscriberInterface
     /**
      * @inheritDoc
      */
-    public static function getSubscribedEvents ()
+    public static function getSubscribedEvents () : array
     {
         return [
             KernelEvents::RESPONSE => "onResponse",

--- a/src/Listener/MonitoringTokenListener.php
+++ b/src/Listener/MonitoringTokenListener.php
@@ -39,7 +39,7 @@ class MonitoringTokenListener implements EventSubscriberInterface
         $response = $event->getResponse();
 
         // skip if not HTML response
-        if (false === \strpos($response->headers->get("Content-Type"), "text/html"))
+        if ($response instanceof BinaryFileResponse || false === \strpos($response->headers->get("Content-Type"), "text/html"))
         {
             return;
         }

--- a/src/Listener/MonitoringTokenListener.php
+++ b/src/Listener/MonitoringTokenListener.php
@@ -4,7 +4,6 @@ namespace Becklyn\Hosting\Listener;
 
 use Becklyn\Hosting\Config\HostingConfig;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
@@ -40,14 +39,14 @@ class MonitoringTokenListener implements EventSubscriberInterface
         $response = $event->getResponse();
 
         // skip if not HTML response
-        if ($response instanceof BinaryFileResponse || false === \strpos($response->headers->get("Content-Type"), "text/html"))
+        if (false === \strpos($response->headers->get("Content-Type"), "text/html"))
         {
             return;
         }
 
         $content = $response->getContent();
 
-        if (false !== ($position = \strrpos($content, '</body>')))
+        if (\is_string($content) && false !== ($position = \strrpos($content, '</body>')))
         {
             $content = \substr($content, 0, $position)
                 . $this->uptimeHtmlEmbed

--- a/src/Listener/MonitoringTokenListener.php
+++ b/src/Listener/MonitoringTokenListener.php
@@ -31,7 +31,7 @@ class MonitoringTokenListener implements EventSubscriberInterface
     public function onResponse (FilterResponseEvent $event) : void
     {
         // skip if not master request
-        if (null === $this->uptimeHtmlEmbed || !$event->isMasterRequest())
+        if (!$event->isMasterRequest() || null === $this->uptimeHtmlEmbed)
         {
             return;
         }


### PR DESCRIPTION
| Q       | A
| ------- | ---
| Bug fix?      | yes
| New feature?  |no <!-- don't forget to update CHANGELOG.md -->
| BC breaks?    | no
| Deprecations? |no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->
| Docs PR | not needed

Unfortunately there was an edge case where we tried to inject our monitoring token into an SVG file download, which would crash we `$response->getContent()` was returning a boolean instead of a string, despite of its PHPDoc.
