### PR TITLE
Don't crash when no content-type is available

### DIFF
--- a/src/Listener/MonitoringTokenListener.php
+++ b/src/Listener/MonitoringTokenListener.php
@@ -37,9 +37,10 @@ class MonitoringTokenListener implements EventSubscriberInterface
         }
 
         $response = $event->getResponse();
+        $contentType = $response->headers->get("Content-Type");
 
         // skip if not HTML response
-        if (false === \strpos($response->headers->get("Content-Type"), "text/html"))
+        if (null === $contentType || false === \strpos($contentType, "text/html"))
         {
             return;
         }

--- a/src/Listener/MonitoringTokenListener.php
+++ b/src/Listener/MonitoringTokenListener.php
@@ -64,7 +64,7 @@ class MonitoringTokenListener implements EventSubscriberInterface
     public static function getSubscribedEvents () : array
     {
         return [
-            KernelEvents::RESPONSE => "onResponse",
+            KernelEvents::RESPONSE => ["onResponse", -1000],
         ];
     }
 }


### PR DESCRIPTION
| Q       | A
| ------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update CHANGELOG.md -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->

Passing `null` into `\strpos` causes an exception. This PR bails out when no `Content-Type` header is set. It also makes sure that the `MonitoringTokenListener` runs last, so all important information are available. The last part may or may not be the root cause for crashes in some consuming projects as Symfony may call event subscribers in a varying order.