### PR TITLE
Reduce the minimum required becklyn assets version

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,10 @@
-| Q       | A
-| ------- | ---
-| Bug fix?      | yes/no
-| New feature?  | yes/no <!-- don't forget to update CHANGELOG.md -->
-| BC breaks?    | no
-| Deprecations? | yes/no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->
-| Docs PR | **missing** <!-- insert URL here -->
+| Q             | A
+| ------------- | --------------------------------------------------------------------- |
+| Bug fix?      | yes/no                                                                |
+| New feature?  | yes/no <!-- don't forget to update CHANGELOG.md -->                   |
+| Improvement?  | yes/no <!-- improves an existing feature, not adding a new one -->    |
+| BC breaks?    | yes/no                                                                |
+| Deprecations? | yes/no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |
+| Docs PR       | **missing** <!-- insert URL here -->                                  |
+
+<!-- describe your changes below -->

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "symfony/http-kernel": "^3.4 || ^4.0"
     },
     "require-dev": {
-        "becklyn/assets-bundle": "^2.6",
+        "becklyn/assets-bundle": "^2.3",
         "becklyn/php-cs": "^2.0.1",
         "symfony/phpunit-bridge": "^4.3.8",
         "twig/twig": "^2.0"


### PR DESCRIPTION
| Q             | A
| ------------- | --------------------------------------------------------------------- |
| Bug fix?      | yes                                                                |
| New feature?  | no <!-- don't forget to update CHANGELOG.md -->                   |
| Improvement?  | no <!-- improves an existing feature, not adding a new one -->    |
| BC breaks?    | no                                                                |
| Deprecations? | no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |
| Docs PR       | — <!-- insert URL here -->                                  |

<!-- describe your changes below -->

* Reduce the minimum required `becklyn/assets-bundle` version to `^2.3`, to fix compatibility with PHP 7.1
* Update Github PR template to most recent version.