### PR TITLE
Explicitly wire sentry client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+2.2.4
+=====
+
+*   (bug) Explicitly wire sentry client. The actual client is a subclass of `Raven_Client` and is therefor
+    not picked up by autowiring.
+
+
 2.2.3
 =====
 

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -17,3 +17,8 @@ services:
         $packages: '@?Symfony\Component\Asset\Packages'
         $environment: '%kernel.environment%'
         $isDebug: '%kernel.debug%'
+
+    # Explicitly wire the client, as the actual client is a subclass of the Raven_Client and is therefor
+    # not picked up by autowiring.
+    Becklyn\Hosting\Sentry\CustomSanitizeDataProcessor:
+        $client: '@sentry.client'


### PR DESCRIPTION
| Q             | A
| ------------- | --------------------------------------------------------------------- |
| BC breaks?    | no                                                                |
| New feature?  | no <!-- don't forget to update CHANGELOG.md -->                   |
| Improvement?  | no <!-- improves an existing feature, not adding a new one -->    |
| Bug fix?      | yes                                                                |
| Deprecations? | no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |
| Docs PR       | — <!-- insert URL here -->                                  |

<!-- describe your changes below -->
Explicitly wire sentry client. The actual client is a subclass of `Raven_Client` and is therefor not picked up by autowiring.

We could either explicitly wire it or overwrite the constructor – but by just explicitly wiring it we are decoupled from any further changes sentry does in their class hierarchy.