### PR TITLE
do not log user in sentry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+3.0.5
+=====
+
+*   (internal) Don't log the current user in sentry. This improves the performance as it does not longer access the `session` in every request.
+
+
 3.0.4
 =====
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 3.0.5
 =====
 
-*   (internal) Don't log the current user in sentry. This improves the performance as it does not longer access the `session` in every request.
+*   (improvement) Don't log the current user in sentry. This improves the performance as it does not longer access the `session` in every request.
 
 
 3.0.4

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -14,3 +14,7 @@ services:
     becklyn_hosting_ignored_errors:
         class: Sentry\Integration\IgnoreErrorsIntegration
 
+    Becklyn\Hosting\Listener\SentryRequestListener:
+        decorates: 'Sentry\SentryBundle\EventListener\RequestListener'
+        arguments:
+            $inner: '@Becklyn\Hosting\Listener\SentryRequestListener.inner'

--- a/src/Listener/SentryRequestListener.php
+++ b/src/Listener/SentryRequestListener.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+
+namespace Becklyn\Hosting\Listener;
+
+use Sentry\SentryBundle\EventListener\RequestListener;
+use Sentry\SentryBundle\EventListener\RequestListenerControllerEvent;
+use Sentry\SentryBundle\EventListener\RequestListenerRequestEvent;
+use Sentry\SentrySdk;
+use Sentry\State\Scope;
+
+final class SentryRequestListener
+{
+    /**
+     * @var RequestListener
+     */
+    private $inner;
+
+
+    public function __construct (RequestListener $inner)
+    {
+        $this->inner = $inner;
+    }
+
+
+    /**
+     * Set the username from the security context by listening on core.request
+     */
+    public function onKernelRequest (RequestListenerRequestEvent $event) : void
+    {
+        if (!$event->isMasterRequest())
+        {
+            return;
+        }
+
+        $currentClient = SentrySdk::getCurrentHub()->getClient();
+
+        if (null === $currentClient || !$currentClient->getOptions()->shouldSendDefaultPii())
+        {
+            return;
+        }
+
+        $userData = [];
+        $userData['ip_address'] = $event->getRequest()->getClientIp();
+
+        SentrySdk::getCurrentHub()->configureScope(function (Scope $scope) use ($userData) : void {
+             $scope->setUser($userData, true);
+        });
+    }
+
+
+    /**
+     */
+    public function onKernelController (RequestListenerControllerEvent $event) : void
+    {
+        $this->inner->onKernelController($event);
+    }
+}

--- a/src/Listener/SentryRequestListener.php
+++ b/src/Listener/SentryRequestListener.php
@@ -21,7 +21,7 @@ final class SentryRequestListener
 
 
     /**
-     * Set the username from the security context by listening on core.request
+     * We do not want to log any user details. Therefore this method is empty.
      */
     public function onKernelRequest (RequestListenerRequestEvent $event) : void
     {

--- a/src/Listener/SentryRequestListener.php
+++ b/src/Listener/SentryRequestListener.php
@@ -5,8 +5,6 @@ namespace Becklyn\Hosting\Listener;
 use Sentry\SentryBundle\EventListener\RequestListener;
 use Sentry\SentryBundle\EventListener\RequestListenerControllerEvent;
 use Sentry\SentryBundle\EventListener\RequestListenerRequestEvent;
-use Sentry\SentrySdk;
-use Sentry\State\Scope;
 
 final class SentryRequestListener
 {
@@ -27,24 +25,7 @@ final class SentryRequestListener
      */
     public function onKernelRequest (RequestListenerRequestEvent $event) : void
     {
-        if (!$event->isMasterRequest())
-        {
-            return;
-        }
 
-        $currentClient = SentrySdk::getCurrentHub()->getClient();
-
-        if (null === $currentClient || !$currentClient->getOptions()->shouldSendDefaultPii())
-        {
-            return;
-        }
-
-        $userData = [];
-        $userData['ip_address'] = $event->getRequest()->getClientIp();
-
-        SentrySdk::getCurrentHub()->configureScope(function (Scope $scope) use ($userData) : void {
-             $scope->setUser($userData, true);
-        });
     }
 
 


### PR DESCRIPTION
| Q             | A
| ------------- | --------------------------------------------------------------------- |
| BC breaks?    |no                                                                |
| New feature?  |no               |
| Improvement?  | yes    |
| Bug fix?      |no                                                                |
| Deprecations? |no    |

Don't log the current user in sentry. This improves the performance as it does not longer access the `session` in every request.
