### PR TITLE
Do not log user in sentry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+2.2.5
+=====
+
+*   (internal) Don't log the current user in sentry. This improves the performance as it does not longer access the `session` in every request.
+
+
 2.2.4
 =====
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,3 +12,4 @@ parameters:
         - '#Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition::#'
         - '#Symfony\\Component\\Config\\Definition\\Builder\\NodeParentInterface::#'
         - '#Symfony\\Component\\Asset\\Packages#'
+        - '#Becklyn\\Hosting\\Listener\\SentryExceptionListener::onConsoleException#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,7 +9,7 @@ parameters:
         - vendor
 
     ignoreErrors:
+        - '#Becklyn\\Hosting\\Listener\\SentryExceptionListener::onConsoleException#'
+        - '#Symfony\\Component\\Asset\\Packages#'
         - '#Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition::#'
         - '#Symfony\\Component\\Config\\Definition\\Builder\\NodeParentInterface::#'
-        - '#Symfony\\Component\\Asset\\Packages#'
-        - '#Becklyn\\Hosting\\Listener\\SentryExceptionListener::onConsoleException#'

--- a/src/Listener/SentryExceptionListener.php
+++ b/src/Listener/SentryExceptionListener.php
@@ -25,7 +25,7 @@ final class SentryExceptionListener implements SentryExceptionListenerInterface
 
 
     /**
-     * @inheritDoc
+     * We do not want to log any user details. Therefore this method is empty.
      */
     public function onKernelRequest (GetResponseEvent $event) : void
     {

--- a/src/Listener/SentryExceptionListener.php
+++ b/src/Listener/SentryExceptionListener.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+
+namespace Becklyn\Hosting\Listener;
+
+use Sentry\SentryBundle\EventListener\ExceptionListener;
+use Sentry\SentryBundle\EventListener\SentryExceptionListenerInterface;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\Console\Event\ConsoleErrorEvent;
+use Symfony\Component\Console\Event\ConsoleExceptionEvent;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+
+final class SentryExceptionListener implements SentryExceptionListenerInterface
+{
+    /**
+     * @var ExceptionListener
+     */
+    private $inner;
+
+
+    public function __construct (ExceptionListener $inner)
+    {
+        $this->inner = $inner;
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function onKernelRequest (GetResponseEvent $event) : void
+    {
+
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function onKernelException (GetResponseForExceptionEvent $event) : void
+    {
+        $this->inner->onKernelException($event);
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function onConsoleError (ConsoleErrorEvent $event) : void
+    {
+        $this->inner->onConsoleError($event);
+    }
+
+
+    public function onConsoleCommand (ConsoleCommandEvent $event) : void
+    {
+        $this->inner->onConsoleCommand($event);
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function onConsoleException (ConsoleExceptionEvent $event) : void
+    {
+        $this->inner->onConsoleException($event);
+    }
+}

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -22,3 +22,8 @@ services:
     # not picked up by autowiring.
     Becklyn\Hosting\Sentry\CustomSanitizeDataProcessor:
         $client: '@sentry.client'
+
+    Becklyn\Hosting\Listener\SentryExceptionListener:
+        decorates: 'sentry.exception_listener'
+        arguments:
+            $inner: '@Becklyn\Hosting\Listener\SentryExceptionListener.inner'


### PR DESCRIPTION
| Q             | A
| ------------- | --------------------------------------------------------------------- |
| BC breaks?    |no                                                                |
| New feature?  |no                   |
| Improvement?  | yes    |
| Bug fix?      |no                                                                |
| Deprecations? |no    |

Don't log the current user in sentry. This improves the performance as it does not longer access the `session` in every request.
